### PR TITLE
Allow multiple rules per policy

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -25,7 +25,26 @@ resource "prismacloudcompute_collection" "example1" {
 resource "prismacloudcompute_policiesruntimecontainer" "example2" {
   learningdisabled = false
   rules {
-    name = "example container runtime rule"
+    name = "example container runtime rule 1"
+    collections {
+      name = "All"
+    }
+    wildfireanalysis = "alert"
+    processes = {
+      "effect" : "alert"
+    }
+    network = {
+      "effect" : "alert"
+    }
+    dns = {
+      "effect" : "disable"
+    }
+    filesystem = {
+      effect = "alert"
+    }
+  }
+  rules {
+    name = "example container runtime rule 2"
     collections {
       name = "All"
     }

--- a/prismacloudcompute/resource_policies_compliance_container.go
+++ b/prismacloudcompute/resource_policies_compliance_container.go
@@ -542,205 +542,206 @@ func parsePolicyComplianceContainer(d *schema.ResourceData, id string) policyCom
 	rules := d.Get("rules").([]interface{})
 	ans.Rules = make([]policy.Rule, 0, len(rules))
 	if len(rules) > 0 {
+		for i := 0; i < len(rules); i++ {
+			item := rules[i].(map[string]interface{})
 
-		item := rules[0].(map[string]interface{})
+			rule := policy.Rule{}
 
-		rule := policy.Rule{}
+			if item["alertthreshold"] != nil {
+				thresholdInterface := item["alertthreshold"].(interface{})
+				rule.AlertThreshold = getThreshold(thresholdInterface)
+			}
+			if item["blockthreshold"] != nil {
+				thresholdInterface := item["blockthreshold"].(interface{})
+				rule.BlockThreshold = getThreshold(thresholdInterface)
+			}
+			if item["collections"] != nil {
+				colls := item["collections"].([]interface{})
 
-		if item["alertthreshold"] != nil {
-			thresholdInterface := item["alertthreshold"].(interface{})
-			rule.AlertThreshold = getThreshold(thresholdInterface)
-		}
-		if item["blockthreshold"] != nil {
-			thresholdInterface := item["blockthreshold"].(interface{})
-			rule.BlockThreshold = getThreshold(thresholdInterface)
-		}
-		if item["collections"] != nil {
-			colls := item["collections"].([]interface{})
+				rule.Collections = make([]collection.Collection, 0, len(colls))
+				if len(colls) > 0 {
+					collItem := colls[0].(map[string]interface{})
 
-			rule.Collections = make([]collection.Collection, 0, len(colls))
-			if len(colls) > 0 {
-				collItem := colls[0].(map[string]interface{})
-
-				rule.Collections = append(rule.Collections, getCollection(collItem))
-			}
-		}
-		if item["condition"] != nil {
-			cond := item["condition"].(map[string]interface{})
-
-			condition := policy.Condition{}
-
-			if cond["vulnerabilities"] != nil {
-				vuln := cond["vulnerabilities"].(map[string]interface{})
-				vulnerabilities := policy.Vulnerability{
-					Block:       vuln["block"].(bool),
-					Id:          vuln["id"].(int),
-					MinSeverity: vuln["minSeverity"].(int),
-				}
-				condition.Vulnerabilities = append(condition.Vulnerabilities, vulnerabilities)
-			}
-		}
-		if item["customrules"] != nil {
-			custRules := item["customrules"].([]interface{})
-			rule.CustomRules = make([]policy.CustomRule, 0, len(custRules))
-			if len(custRules) > 0 {
-				custRuleItem := custRules[0].(map[string]interface{})
-
-				custRule := policy.CustomRule{
-					Id:     custRuleItem["_id"].(int),
-					Action: custRuleItem["action"].([]string),
-					Effect: custRuleItem["effect"].(string),
-				}
-				rule.CustomRules = append(rule.CustomRules, custRule)
-			}
-		}
-		if item["disabled"] != nil {
-			rule.Disabled = item["disabled"].(bool)
-		}
-		if item["filesystem"] != nil {
-			fileSysSet := item["filesystem"].(interface{})
-			fileSysItem := fileSysSet.(map[string]interface{})
-
-			rule.Filesystem = policy.Filesystem{}
-			if fileSysItem["blacklist"] != nil {
-				rule.Filesystem.BackdoorFiles = fileSysItem["backdoorFiles"].(bool)
-			}
-			if fileSysItem["blacklist"] != nil {
-				rule.Filesystem.Blacklist = fileSysItem["blacklist"].([]string)
-			}
-			if fileSysItem["checkNewFiles"] != nil {
-				rule.Filesystem.CheckNewFiles = fileSysItem["checkNewFiles"].(bool)
-			}
-			if fileSysItem["effect"] != nil {
-				rule.Filesystem.Effect = fileSysItem["effect"].(string)
-			}
-			if fileSysItem["skipEncryptedBinaries"] != nil {
-				rule.Filesystem.SkipEncryptedBinaries = fileSysItem["skipEncryptedBinaries"].(bool)
-			}
-			if fileSysItem["suspiciousELFHeaders"] != nil {
-				rule.Filesystem.SuspiciousELFHeaders = fileSysItem["suspiciousELFHeaders"].(bool)
-			}
-			if fileSysItem["whitelist"] != nil {
-				rule.Filesystem.Whitelist = fileSysItem["whitelist"].([]string)
-			}
-		}
-		if item["kubernetesenforcement"] != nil {
-			rule.KubernetesEnforcement = item["kubernetesenforcement"].(bool)
-		}
-		if item["modified"] != nil {
-			rule.Modified = item["modified"].(string)
-		}
-		if item["name"] != nil {
-			rule.Name = item["name"].(string)
-		}
-		if item["network"] != nil {
-			networkSet := item["network"].(interface{})
-			networkItem := networkSet.(map[string]interface{})
-			if networkItem["blacklistIPs"] != nil {
-				rule.Network.BlacklistIPs = networkItem["blacklistIPs"].([]string)
-			}
-
-			if networkItem["blacklistListeningPorts"] != nil {
-				blacklistListenPorts := networkItem["blacklistListeningPorts"].([]interface{})
-				rule.Network.BlacklistListeningPorts = make([]policy.ListPort, 0, len(blacklistListenPorts))
-				if len(blacklistListenPorts) > 0 {
-					rule.Network.BlacklistListeningPorts = append(rule.Network.BlacklistListeningPorts, getListPort(blacklistListenPorts[0]))
+					rule.Collections = append(rule.Collections, getCollection(collItem))
 				}
 			}
+			if item["condition"] != nil {
+				cond := item["condition"].(map[string]interface{})
 
-			if networkItem["blacklistOutboundPorts"] != nil {
-				blacklistOutPorts := networkItem["blacklistOutboundPorts"].([]interface{})
-				rule.Network.BlacklistOutboundPorts = make([]policy.ListPort, 0, len(blacklistOutPorts))
-				if len(blacklistOutPorts) > 0 {
-					rule.Network.BlacklistOutboundPorts = append(rule.Network.BlacklistOutboundPorts, getListPort(blacklistOutPorts[0]))
+				condition := policy.Condition{}
+
+				if cond["vulnerabilities"] != nil {
+					vuln := cond["vulnerabilities"].(map[string]interface{})
+					vulnerabilities := policy.Vulnerability{
+						Block:       vuln["block"].(bool),
+						Id:          vuln["id"].(int),
+						MinSeverity: vuln["minSeverity"].(int),
+					}
+					condition.Vulnerabilities = append(condition.Vulnerabilities, vulnerabilities)
 				}
 			}
-			if networkItem["blacklistOutboundPorts"] != nil {
-				rule.Network.DetectPortScan = networkItem["detectPortScan"].(bool)
-			}
-			if networkItem["effect"] != nil {
-				rule.Network.Effect = networkItem["effect"].(string)
-			}
-			if networkItem["skipModifiedProc"] != nil {
-				rule.Network.SkipModifiedProc = networkItem["skipModifiedProc"].(bool)
-			}
-			if networkItem["skipRawSockets"] != nil {
-				rule.Network.SkipRawSockets = networkItem["skipRawSockets"].(bool)
-			}
-			if networkItem["whitelistIPs"] != nil {
-				rule.Network.WhitelistIPs = networkItem["whitelistIPs"].([]string)
-			}
+			if item["customrules"] != nil {
+				custRules := item["customrules"].([]interface{})
+				rule.CustomRules = make([]policy.CustomRule, 0, len(custRules))
+				if len(custRules) > 0 {
+					custRuleItem := custRules[0].(map[string]interface{})
 
-			if networkItem["whitelistListeningPorts"] != nil {
-				whitelistListenPorts := networkItem["whitelistListeningPorts"].([]interface{})
-				rule.Network.WhitelistListeningPorts = make([]policy.ListPort, 0, len(whitelistListenPorts))
-				if len(whitelistListenPorts) > 0 {
-					rule.Network.WhitelistListeningPorts = append(rule.Network.WhitelistListeningPorts, getListPort(whitelistListenPorts[0]))
+					custRule := policy.CustomRule{
+						Id:     custRuleItem["_id"].(int),
+						Action: custRuleItem["action"].([]string),
+						Effect: custRuleItem["effect"].(string),
+					}
+					rule.CustomRules = append(rule.CustomRules, custRule)
 				}
 			}
+			if item["disabled"] != nil {
+				rule.Disabled = item["disabled"].(bool)
+			}
+			if item["filesystem"] != nil {
+				fileSysSet := item["filesystem"].(interface{})
+				fileSysItem := fileSysSet.(map[string]interface{})
 
-			if networkItem["whitelistOutboundPorts"] != nil {
-				whitelistOutPorts := networkItem["whitelistOutboundPorts"].([]interface{})
-				rule.Network.WhitelistOutboundPorts = make([]policy.ListPort, 0, len(whitelistOutPorts))
-				if len(whitelistOutPorts) > 0 {
-					rule.Network.WhitelistOutboundPorts = append(rule.Network.WhitelistOutboundPorts, getListPort(whitelistOutPorts[0]))
+				rule.Filesystem = policy.Filesystem{}
+				if fileSysItem["blacklist"] != nil {
+					rule.Filesystem.BackdoorFiles = fileSysItem["backdoorFiles"].(bool)
+				}
+				if fileSysItem["blacklist"] != nil {
+					rule.Filesystem.Blacklist = fileSysItem["blacklist"].([]string)
+				}
+				if fileSysItem["checkNewFiles"] != nil {
+					rule.Filesystem.CheckNewFiles = fileSysItem["checkNewFiles"].(bool)
+				}
+				if fileSysItem["effect"] != nil {
+					rule.Filesystem.Effect = fileSysItem["effect"].(string)
+				}
+				if fileSysItem["skipEncryptedBinaries"] != nil {
+					rule.Filesystem.SkipEncryptedBinaries = fileSysItem["skipEncryptedBinaries"].(bool)
+				}
+				if fileSysItem["suspiciousELFHeaders"] != nil {
+					rule.Filesystem.SuspiciousELFHeaders = fileSysItem["suspiciousELFHeaders"].(bool)
+				}
+				if fileSysItem["whitelist"] != nil {
+					rule.Filesystem.Whitelist = fileSysItem["whitelist"].([]string)
 				}
 			}
-		}
-		if item["notes"] != nil {
-			rule.Notes = item["notes"].(string)
-		}
-		if item["owner"] != nil {
-			rule.Owner = item["owner"].(string)
-		}
-		if item["previousname"] != nil {
-			rule.PreviousName = item["previousname"].(string)
-		}
-		if item["processes"] != nil {
-			processSet := item["processes"].(interface{})
-			processItem := processSet.(map[string]interface{})
+			if item["kubernetesenforcement"] != nil {
+				rule.KubernetesEnforcement = item["kubernetesenforcement"].(bool)
+			}
+			if item["modified"] != nil {
+				rule.Modified = item["modified"].(string)
+			}
+			if item["name"] != nil {
+				rule.Name = item["name"].(string)
+			}
+			if item["network"] != nil {
+				networkSet := item["network"].(interface{})
+				networkItem := networkSet.(map[string]interface{})
+				if networkItem["blacklistIPs"] != nil {
+					rule.Network.BlacklistIPs = networkItem["blacklistIPs"].([]string)
+				}
 
-			rule.Processes = policy.Processes{}
+				if networkItem["blacklistListeningPorts"] != nil {
+					blacklistListenPorts := networkItem["blacklistListeningPorts"].([]interface{})
+					rule.Network.BlacklistListeningPorts = make([]policy.ListPort, 0, len(blacklistListenPorts))
+					if len(blacklistListenPorts) > 0 {
+						rule.Network.BlacklistListeningPorts = append(rule.Network.BlacklistListeningPorts, getListPort(blacklistListenPorts[0]))
+					}
+				}
 
-			if processItem["blacklist"] != nil {
-				rule.Processes.Blacklist = processItem["blacklist"].([]string)
-			}
-			if processItem["blockAllBinaries"] != nil {
-				rule.Processes.BlockAllBinaries = processItem["blockAllBinaries"].(bool)
-			}
-			if processItem["checkCryptoMiners"] != nil {
-				rule.Processes.CheckCryptoMiners = processItem["checkCryptoMiners"].(bool)
-			}
-			if processItem["checkLateralMovement"] != nil {
-				rule.Processes.CheckLateralMovement = processItem["checkLateralMovement"].(bool)
-			}
-			if processItem["checkNewBinaries"] != nil {
-				rule.Processes.CheckNewBinaries = processItem["checkNewBinaries"].(bool)
-			}
-			if processItem["checkParentChild"] != nil {
-				rule.Processes.CheckParentChild = processItem["checkParentChild"].(bool)
-			}
-			if processItem["checkSuidBinaries"] != nil {
-				rule.Processes.CheckSuidBinaries = processItem["checkSuidBinaries"].(bool)
-			}
-			if processItem["effect"] != nil {
-				rule.Processes.Effect = processItem["effect"].(string)
-			}
-			if processItem["skipModified"] != nil {
-				rule.Processes.SkipModified = processItem["skipModified"].(bool)
-			}
-			if processItem["skipReverseShell"] != nil {
-				rule.Processes.SkipReverseShell = processItem["skipReverseShell"].(bool)
-			}
-			if processItem["whitelist"] != nil {
-				rule.Processes.Whitelist = processItem["whitelist"].([]string)
-			}
-		}
-		if item["wildfireanalysis"] != nil {
-			rule.WildFireAnalysis = item["wildfireanalysis"].(string)
-		}
+				if networkItem["blacklistOutboundPorts"] != nil {
+					blacklistOutPorts := networkItem["blacklistOutboundPorts"].([]interface{})
+					rule.Network.BlacklistOutboundPorts = make([]policy.ListPort, 0, len(blacklistOutPorts))
+					if len(blacklistOutPorts) > 0 {
+						rule.Network.BlacklistOutboundPorts = append(rule.Network.BlacklistOutboundPorts, getListPort(blacklistOutPorts[0]))
+					}
+				}
+				if networkItem["blacklistOutboundPorts"] != nil {
+					rule.Network.DetectPortScan = networkItem["detectPortScan"].(bool)
+				}
+				if networkItem["effect"] != nil {
+					rule.Network.Effect = networkItem["effect"].(string)
+				}
+				if networkItem["skipModifiedProc"] != nil {
+					rule.Network.SkipModifiedProc = networkItem["skipModifiedProc"].(bool)
+				}
+				if networkItem["skipRawSockets"] != nil {
+					rule.Network.SkipRawSockets = networkItem["skipRawSockets"].(bool)
+				}
+				if networkItem["whitelistIPs"] != nil {
+					rule.Network.WhitelistIPs = networkItem["whitelistIPs"].([]string)
+				}
 
-		ans.Rules = append(ans.Rules, rule)
+				if networkItem["whitelistListeningPorts"] != nil {
+					whitelistListenPorts := networkItem["whitelistListeningPorts"].([]interface{})
+					rule.Network.WhitelistListeningPorts = make([]policy.ListPort, 0, len(whitelistListenPorts))
+					if len(whitelistListenPorts) > 0 {
+						rule.Network.WhitelistListeningPorts = append(rule.Network.WhitelistListeningPorts, getListPort(whitelistListenPorts[0]))
+					}
+				}
+
+				if networkItem["whitelistOutboundPorts"] != nil {
+					whitelistOutPorts := networkItem["whitelistOutboundPorts"].([]interface{})
+					rule.Network.WhitelistOutboundPorts = make([]policy.ListPort, 0, len(whitelistOutPorts))
+					if len(whitelistOutPorts) > 0 {
+						rule.Network.WhitelistOutboundPorts = append(rule.Network.WhitelistOutboundPorts, getListPort(whitelistOutPorts[0]))
+					}
+				}
+			}
+			if item["notes"] != nil {
+				rule.Notes = item["notes"].(string)
+			}
+			if item["owner"] != nil {
+				rule.Owner = item["owner"].(string)
+			}
+			if item["previousname"] != nil {
+				rule.PreviousName = item["previousname"].(string)
+			}
+			if item["processes"] != nil {
+				processSet := item["processes"].(interface{})
+				processItem := processSet.(map[string]interface{})
+
+				rule.Processes = policy.Processes{}
+
+				if processItem["blacklist"] != nil {
+					rule.Processes.Blacklist = processItem["blacklist"].([]string)
+				}
+				if processItem["blockAllBinaries"] != nil {
+					rule.Processes.BlockAllBinaries = processItem["blockAllBinaries"].(bool)
+				}
+				if processItem["checkCryptoMiners"] != nil {
+					rule.Processes.CheckCryptoMiners = processItem["checkCryptoMiners"].(bool)
+				}
+				if processItem["checkLateralMovement"] != nil {
+					rule.Processes.CheckLateralMovement = processItem["checkLateralMovement"].(bool)
+				}
+				if processItem["checkNewBinaries"] != nil {
+					rule.Processes.CheckNewBinaries = processItem["checkNewBinaries"].(bool)
+				}
+				if processItem["checkParentChild"] != nil {
+					rule.Processes.CheckParentChild = processItem["checkParentChild"].(bool)
+				}
+				if processItem["checkSuidBinaries"] != nil {
+					rule.Processes.CheckSuidBinaries = processItem["checkSuidBinaries"].(bool)
+				}
+				if processItem["effect"] != nil {
+					rule.Processes.Effect = processItem["effect"].(string)
+				}
+				if processItem["skipModified"] != nil {
+					rule.Processes.SkipModified = processItem["skipModified"].(bool)
+				}
+				if processItem["skipReverseShell"] != nil {
+					rule.Processes.SkipReverseShell = processItem["skipReverseShell"].(bool)
+				}
+				if processItem["whitelist"] != nil {
+					rule.Processes.Whitelist = processItem["whitelist"].([]string)
+				}
+			}
+			if item["wildfireanalysis"] != nil {
+				rule.WildFireAnalysis = item["wildfireanalysis"].(string)
+			}
+
+			ans.Rules = append(ans.Rules, rule)
+		}
 	}
 
 	return ans

--- a/prismacloudcompute/resource_policies_runtime_container.go
+++ b/prismacloudcompute/resource_policies_runtime_container.go
@@ -549,213 +549,215 @@ func parsePolicy(d *schema.ResourceData, id string) policyRuntimeContainer.Polic
 	ans.Rules = make([]policy.Rule, 0, len(rules))
 	if len(rules) > 0 {
 
-		item := rules[0].(map[string]interface{})
+		for i := 0; i < len(rules); i++ {
+			item := rules[i].(map[string]interface{})
 
-		rule := policy.Rule{}
+			rule := policy.Rule{}
 
-		if item["advancedprotection"] != nil {
-			rule.AdvancedProtection = item["advancedprotection"].(bool)
-		}
-		if item["cloudmetadataenforcement"] != nil {
-			rule.CloudMetadataEnforcement = item["cloudmetadataenforcement"].(bool)
-		}
-		if item["collections"] != nil {
-			colls := item["collections"].([]interface{})
-
-			rule.Collections = make([]collection.Collection, 0, len(colls))
-			if len(colls) > 0 {
-				collItem := colls[0].(map[string]interface{})
-
-				rule.Collections = append(rule.Collections, getCollection(collItem))
+			if item["advancedprotection"] != nil {
+				rule.AdvancedProtection = item["advancedprotection"].(bool)
 			}
+			if item["cloudmetadataenforcement"] != nil {
+				rule.CloudMetadataEnforcement = item["cloudmetadataenforcement"].(bool)
+			}
+			if item["collections"] != nil {
+				colls := item["collections"].([]interface{})
 
-		}
-		if item["customrules"] != nil {
-			custRules := item["customrules"].([]interface{})
-			rule.CustomRules = make([]policy.CustomRule, 0, len(custRules))
-			if len(custRules) > 0 {
-				for i := 0; i < len(custRules); i++ {
-					custRuleItem := custRules[i].(map[string]interface{})
+				rule.Collections = make([]collection.Collection, 0, len(colls))
+				if len(colls) > 0 {
+					collItem := colls[0].(map[string]interface{})
 
-					custRule := policy.CustomRule{
-						Id:     custRuleItem["_id"].(int),
-						Action: custRuleItem["action"].([]string),
-						Effect: custRuleItem["effect"].(string),
-					}
-					rule.CustomRules = append(rule.CustomRules, custRule)
+					rule.Collections = append(rule.Collections, getCollection(collItem))
 				}
-			}
-		}
-		if item["disabled"] != nil {
-			rule.Disabled = item["disabled"].(bool)
-		}
-		if item["dns"] != nil {
-			dnsSet := item["dns"].(interface{})
-			dnsItem := dnsSet.(map[string]interface{})
 
-			rule.Dns = policy.Dns{}
-			if dnsItem["blacklist"] != nil {
-				rule.Dns.Blacklist = dnsItem["blacklist"].([]string)
 			}
-			if dnsItem["effect"] != nil {
-				rule.Dns.Effect = dnsItem["effect"].(string)
-			}
-			if dnsItem["whitelist"] != nil {
-				rule.Dns.Whitelist = dnsItem["whitelist"].([]string)
-			}
-		}
-		if item["filesystem"] != nil {
-			fileSysSet := item["filesystem"].(interface{})
-			fileSysItem := fileSysSet.(map[string]interface{})
+			if item["customrules"] != nil {
+				custRules := item["customrules"].([]interface{})
+				rule.CustomRules = make([]policy.CustomRule, 0, len(custRules))
+				if len(custRules) > 0 {
+					for i := 0; i < len(custRules); i++ {
+						custRuleItem := custRules[i].(map[string]interface{})
 
-			rule.Filesystem = policy.Filesystem{}
-			if fileSysItem["backdoorFiles"] != nil {
-				rule.Filesystem.BackdoorFiles = fileSysItem["backdoorFiles"].(bool)
-			}
-			if fileSysItem["blacklist"] != nil {
-				rule.Filesystem.Blacklist = fileSysItem["blacklist"].([]string)
-			}
-			if fileSysItem["checkNewFiles"] != nil {
-				rule.Filesystem.CheckNewFiles = fileSysItem["checkNewFiles"].(bool)
-			}
-			if fileSysItem["effect"] != nil {
-				rule.Filesystem.Effect = fileSysItem["effect"].(string)
-			}
-			if fileSysItem["skipEncryptedBinaries"] != nil {
-				rule.Filesystem.SkipEncryptedBinaries = fileSysItem["skipEncryptedBinaries"].(bool)
-			}
-			if fileSysItem["suspiciousELFHeaders"] != nil {
-				rule.Filesystem.SuspiciousELFHeaders = fileSysItem["suspiciousELFHeaders"].(bool)
-			}
-			if fileSysItem["whitelist"] != nil {
-				rule.Filesystem.Whitelist = fileSysItem["whitelist"].([]string)
-			}
-		}
-		if item["kubernetesenforcement"] != nil {
-			rule.KubernetesEnforcement = item["kubernetesenforcement"].(bool)
-		}
-		if item["modified"] != nil {
-			rule.Modified = item["modified"].(string)
-		}
-		if item["name"] != nil {
-			rule.Name = item["name"].(string)
-		}
-		if item["network"] != nil {
-			networkSet := item["network"].(interface{})
-			networkItem := networkSet.(map[string]interface{})
-			if networkItem["blacklistIPs"] != nil {
-				rule.Network.BlacklistIPs = networkItem["blacklistIPs"].([]string)
-			}
-
-			if networkItem["blacklistListeningPorts"] != nil {
-				blacklistListenPorts := networkItem["blacklistListeningPorts"].([]interface{})
-				rule.Network.BlacklistListeningPorts = make([]policy.ListPort, 0, len(blacklistListenPorts))
-				if len(blacklistListenPorts) > 0 {
-					for i := 0; i < len(blacklistListenPorts); i++ {
-						rule.Network.BlacklistListeningPorts = append(rule.Network.BlacklistListeningPorts, getListPort(blacklistListenPorts[i]))
+						custRule := policy.CustomRule{
+							Id:     custRuleItem["_id"].(int),
+							Action: custRuleItem["action"].([]string),
+							Effect: custRuleItem["effect"].(string),
+						}
+						rule.CustomRules = append(rule.CustomRules, custRule)
 					}
 				}
 			}
+			if item["disabled"] != nil {
+				rule.Disabled = item["disabled"].(bool)
+			}
+			if item["dns"] != nil {
+				dnsSet := item["dns"].(interface{})
+				dnsItem := dnsSet.(map[string]interface{})
 
-			if networkItem["blacklistOutboundPorts"] != nil {
-				blacklistOutPorts := networkItem["blacklistOutboundPorts"].([]interface{})
-				rule.Network.BlacklistOutboundPorts = make([]policy.ListPort, 0, len(blacklistOutPorts))
-				if len(blacklistOutPorts) > 0 {
-					for i := 0; i < len(blacklistOutPorts); i++ {
-						rule.Network.BlacklistOutboundPorts = append(rule.Network.BlacklistOutboundPorts, getListPort(blacklistOutPorts[i]))
+				rule.Dns = policy.Dns{}
+				if dnsItem["blacklist"] != nil {
+					rule.Dns.Blacklist = dnsItem["blacklist"].([]string)
+				}
+				if dnsItem["effect"] != nil {
+					rule.Dns.Effect = dnsItem["effect"].(string)
+				}
+				if dnsItem["whitelist"] != nil {
+					rule.Dns.Whitelist = dnsItem["whitelist"].([]string)
+				}
+			}
+			if item["filesystem"] != nil {
+				fileSysSet := item["filesystem"].(interface{})
+				fileSysItem := fileSysSet.(map[string]interface{})
+
+				rule.Filesystem = policy.Filesystem{}
+				if fileSysItem["backdoorFiles"] != nil {
+					rule.Filesystem.BackdoorFiles = fileSysItem["backdoorFiles"].(bool)
+				}
+				if fileSysItem["blacklist"] != nil {
+					rule.Filesystem.Blacklist = fileSysItem["blacklist"].([]string)
+				}
+				if fileSysItem["checkNewFiles"] != nil {
+					rule.Filesystem.CheckNewFiles = fileSysItem["checkNewFiles"].(bool)
+				}
+				if fileSysItem["effect"] != nil {
+					rule.Filesystem.Effect = fileSysItem["effect"].(string)
+				}
+				if fileSysItem["skipEncryptedBinaries"] != nil {
+					rule.Filesystem.SkipEncryptedBinaries = fileSysItem["skipEncryptedBinaries"].(bool)
+				}
+				if fileSysItem["suspiciousELFHeaders"] != nil {
+					rule.Filesystem.SuspiciousELFHeaders = fileSysItem["suspiciousELFHeaders"].(bool)
+				}
+				if fileSysItem["whitelist"] != nil {
+					rule.Filesystem.Whitelist = fileSysItem["whitelist"].([]string)
+				}
+			}
+			if item["kubernetesenforcement"] != nil {
+				rule.KubernetesEnforcement = item["kubernetesenforcement"].(bool)
+			}
+			if item["modified"] != nil {
+				rule.Modified = item["modified"].(string)
+			}
+			if item["name"] != nil {
+				rule.Name = item["name"].(string)
+			}
+			if item["network"] != nil {
+				networkSet := item["network"].(interface{})
+				networkItem := networkSet.(map[string]interface{})
+				if networkItem["blacklistIPs"] != nil {
+					rule.Network.BlacklistIPs = networkItem["blacklistIPs"].([]string)
+				}
+
+				if networkItem["blacklistListeningPorts"] != nil {
+					blacklistListenPorts := networkItem["blacklistListeningPorts"].([]interface{})
+					rule.Network.BlacklistListeningPorts = make([]policy.ListPort, 0, len(blacklistListenPorts))
+					if len(blacklistListenPorts) > 0 {
+						for i := 0; i < len(blacklistListenPorts); i++ {
+							rule.Network.BlacklistListeningPorts = append(rule.Network.BlacklistListeningPorts, getListPort(blacklistListenPorts[i]))
+						}
+					}
+				}
+
+				if networkItem["blacklistOutboundPorts"] != nil {
+					blacklistOutPorts := networkItem["blacklistOutboundPorts"].([]interface{})
+					rule.Network.BlacklistOutboundPorts = make([]policy.ListPort, 0, len(blacklistOutPorts))
+					if len(blacklistOutPorts) > 0 {
+						for i := 0; i < len(blacklistOutPorts); i++ {
+							rule.Network.BlacklistOutboundPorts = append(rule.Network.BlacklistOutboundPorts, getListPort(blacklistOutPorts[i]))
+						}
+					}
+				}
+				if networkItem["blacklistOutboundPorts"] != nil {
+					rule.Network.DetectPortScan = networkItem["detectPortScan"].(bool)
+				}
+				if networkItem["effect"] != nil {
+					rule.Network.Effect = networkItem["effect"].(string)
+				}
+				if networkItem["skipModifiedProc"] != nil {
+					rule.Network.SkipModifiedProc = networkItem["skipModifiedProc"].(bool)
+				}
+				if networkItem["skipRawSockets"] != nil {
+					rule.Network.SkipRawSockets = networkItem["skipRawSockets"].(bool)
+				}
+				if networkItem["whitelistIPs"] != nil {
+					rule.Network.WhitelistIPs = networkItem["whitelistIPs"].([]string)
+				}
+
+				if networkItem["whitelistListeningPorts"] != nil {
+					whitelistListenPorts := networkItem["whitelistListeningPorts"].([]interface{})
+					rule.Network.WhitelistListeningPorts = make([]policy.ListPort, 0, len(whitelistListenPorts))
+					if len(whitelistListenPorts) > 0 {
+						for i := 0; i < len(whitelistListenPorts); i++ {
+							rule.Network.WhitelistListeningPorts = append(rule.Network.WhitelistListeningPorts, getListPort(whitelistListenPorts[i]))
+						}
+					}
+				}
+
+				if networkItem["whitelistOutboundPorts"] != nil {
+					whitelistOutPorts := networkItem["whitelistOutboundPorts"].([]interface{})
+					rule.Network.WhitelistOutboundPorts = make([]policy.ListPort, 0, len(whitelistOutPorts))
+					if len(whitelistOutPorts) > 0 {
+						for i := 0; i < len(whitelistOutPorts); i++ {
+							rule.Network.WhitelistOutboundPorts = append(rule.Network.WhitelistOutboundPorts, getListPort(whitelistOutPorts[i]))
+						}
 					}
 				}
 			}
-			if networkItem["blacklistOutboundPorts"] != nil {
-				rule.Network.DetectPortScan = networkItem["detectPortScan"].(bool)
+			if item["notes"] != nil {
+				rule.Notes = item["notes"].(string)
 			}
-			if networkItem["effect"] != nil {
-				rule.Network.Effect = networkItem["effect"].(string)
+			if item["owner"] != nil {
+				rule.Owner = item["owner"].(string)
 			}
-			if networkItem["skipModifiedProc"] != nil {
-				rule.Network.SkipModifiedProc = networkItem["skipModifiedProc"].(bool)
+			if item["previousname"] != nil {
+				rule.PreviousName = item["previousname"].(string)
 			}
-			if networkItem["skipRawSockets"] != nil {
-				rule.Network.SkipRawSockets = networkItem["skipRawSockets"].(bool)
-			}
-			if networkItem["whitelistIPs"] != nil {
-				rule.Network.WhitelistIPs = networkItem["whitelistIPs"].([]string)
-			}
+			if item["processes"] != nil {
+				processSet := item["processes"].(interface{})
+				processItem := processSet.(map[string]interface{})
 
-			if networkItem["whitelistListeningPorts"] != nil {
-				whitelistListenPorts := networkItem["whitelistListeningPorts"].([]interface{})
-				rule.Network.WhitelistListeningPorts = make([]policy.ListPort, 0, len(whitelistListenPorts))
-				if len(whitelistListenPorts) > 0 {
-					for i := 0; i < len(whitelistListenPorts); i++ {
-						rule.Network.WhitelistListeningPorts = append(rule.Network.WhitelistListeningPorts, getListPort(whitelistListenPorts[i]))
-					}
+				rule.Processes = policy.Processes{}
+
+				if processItem["blacklist"] != nil {
+					rule.Processes.Blacklist = processItem["blacklist"].([]string)
+				}
+				if processItem["blockAllBinaries"] != nil {
+					rule.Processes.BlockAllBinaries = processItem["blockAllBinaries"].(bool)
+				}
+				if processItem["checkCryptoMiners"] != nil {
+					rule.Processes.CheckCryptoMiners = processItem["checkCryptoMiners"].(bool)
+				}
+				if processItem["checkLateralMovement"] != nil {
+					rule.Processes.CheckLateralMovement = processItem["checkLateralMovement"].(bool)
+				}
+				if processItem["checkNewBinaries"] != nil {
+					rule.Processes.CheckNewBinaries = processItem["checkNewBinaries"].(bool)
+				}
+				if processItem["checkParentChild"] != nil {
+					rule.Processes.CheckParentChild = processItem["checkParentChild"].(bool)
+				}
+				if processItem["checkSuidBinaries"] != nil {
+					rule.Processes.CheckSuidBinaries = processItem["checkSuidBinaries"].(bool)
+				}
+				if processItem["effect"] != nil {
+					rule.Processes.Effect = processItem["effect"].(string)
+				}
+				if processItem["skipModified"] != nil {
+					rule.Processes.SkipModified = processItem["skipModified"].(bool)
+				}
+				if processItem["skipReverseShell"] != nil {
+					rule.Processes.SkipReverseShell = processItem["skipReverseShell"].(bool)
+				}
+				if processItem["whitelist"] != nil {
+					rule.Processes.Whitelist = processItem["whitelist"].([]string)
 				}
 			}
+			if item["wildfireanalysis"] != nil {
+				rule.WildFireAnalysis = item["wildfireanalysis"].(string)
+			}
 
-			if networkItem["whitelistOutboundPorts"] != nil {
-				whitelistOutPorts := networkItem["whitelistOutboundPorts"].([]interface{})
-				rule.Network.WhitelistOutboundPorts = make([]policy.ListPort, 0, len(whitelistOutPorts))
-				if len(whitelistOutPorts) > 0 {
-					for i := 0; i < len(whitelistOutPorts); i++ {
-						rule.Network.WhitelistOutboundPorts = append(rule.Network.WhitelistOutboundPorts, getListPort(whitelistOutPorts[i]))
-					}
-				}
-			}
+			ans.Rules = append(ans.Rules, rule)
 		}
-		if item["notes"] != nil {
-			rule.Notes = item["notes"].(string)
-		}
-		if item["owner"] != nil {
-			rule.Owner = item["owner"].(string)
-		}
-		if item["previousname"] != nil {
-			rule.PreviousName = item["previousname"].(string)
-		}
-		if item["processes"] != nil {
-			processSet := item["processes"].(interface{})
-			processItem := processSet.(map[string]interface{})
-
-			rule.Processes = policy.Processes{}
-
-			if processItem["blacklist"] != nil {
-				rule.Processes.Blacklist = processItem["blacklist"].([]string)
-			}
-			if processItem["blockAllBinaries"] != nil {
-				rule.Processes.BlockAllBinaries = processItem["blockAllBinaries"].(bool)
-			}
-			if processItem["checkCryptoMiners"] != nil {
-				rule.Processes.CheckCryptoMiners = processItem["checkCryptoMiners"].(bool)
-			}
-			if processItem["checkLateralMovement"] != nil {
-				rule.Processes.CheckLateralMovement = processItem["checkLateralMovement"].(bool)
-			}
-			if processItem["checkNewBinaries"] != nil {
-				rule.Processes.CheckNewBinaries = processItem["checkNewBinaries"].(bool)
-			}
-			if processItem["checkParentChild"] != nil {
-				rule.Processes.CheckParentChild = processItem["checkParentChild"].(bool)
-			}
-			if processItem["checkSuidBinaries"] != nil {
-				rule.Processes.CheckSuidBinaries = processItem["checkSuidBinaries"].(bool)
-			}
-			if processItem["effect"] != nil {
-				rule.Processes.Effect = processItem["effect"].(string)
-			}
-			if processItem["skipModified"] != nil {
-				rule.Processes.SkipModified = processItem["skipModified"].(bool)
-			}
-			if processItem["skipReverseShell"] != nil {
-				rule.Processes.SkipReverseShell = processItem["skipReverseShell"].(bool)
-			}
-			if processItem["whitelist"] != nil {
-				rule.Processes.Whitelist = processItem["whitelist"].([]string)
-			}
-		}
-		if item["wildfireanalysis"] != nil {
-			rule.WildFireAnalysis = item["wildfireanalysis"].(string)
-		}
-
-		ans.Rules = append(ans.Rules, rule)
 	}
 
 	return ans

--- a/prismacloudcompute/resource_policies_vulnerability_images.go
+++ b/prismacloudcompute/resource_policies_vulnerability_images.go
@@ -543,205 +543,207 @@ func parsePolicyVulnerabilityImages(d *schema.ResourceData, id string) policyVul
 	rules := d.Get("rules").([]interface{})
 	ans.Rules = make([]policy.Rule, 0, len(rules))
 	if len(rules) > 0 {
+		for i := 0; i < len(rules); i++ {
 
-		item := rules[0].(map[string]interface{})
+			item := rules[i].(map[string]interface{})
 
-		rule := policy.Rule{}
+			rule := policy.Rule{}
 
-		if item["alertthreshold"] != nil {
-			thresholdInterface := item["alertthreshold"]
-			rule.AlertThreshold = getThreshold(thresholdInterface)
-		}
-		if item["blockthreshold"] != nil {
-			thresholdInterface := item["blockthreshold"].(interface{})
-			rule.BlockThreshold = getThreshold(thresholdInterface)
-		}
-		if item["collections"] != nil {
-			colls := item["collections"].([]interface{})
+			if item["alertthreshold"] != nil {
+				thresholdInterface := item["alertthreshold"]
+				rule.AlertThreshold = getThreshold(thresholdInterface)
+			}
+			if item["blockthreshold"] != nil {
+				thresholdInterface := item["blockthreshold"].(interface{})
+				rule.BlockThreshold = getThreshold(thresholdInterface)
+			}
+			if item["collections"] != nil {
+				colls := item["collections"].([]interface{})
 
-			rule.Collections = make([]collection.Collection, 0, len(colls))
-			if len(colls) > 0 {
-				collItem := colls[0].(map[string]interface{})
+				rule.Collections = make([]collection.Collection, 0, len(colls))
+				if len(colls) > 0 {
+					collItem := colls[0].(map[string]interface{})
 
-				rule.Collections = append(rule.Collections, getCollection(collItem))
-			}
-		}
-		if item["condition"] != nil {
-			cond := item["condition"].(map[string]interface{})
-
-			condition := policy.Condition{}
-
-			if cond["vulnerabilities"] != nil {
-				vuln := cond["vulnerabilities"].(map[string]interface{})
-				vulnerabilities := policy.Vulnerability{
-					Block:       vuln["block"].(bool),
-					Id:          vuln["id"].(int),
-					MinSeverity: vuln["minSeverity"].(int),
-				}
-				condition.Vulnerabilities = append(condition.Vulnerabilities, vulnerabilities)
-			}
-		}
-		if item["customrules"] != nil {
-			custRules := item["customrules"].([]interface{})
-			rule.CustomRules = make([]policy.CustomRule, 0, len(custRules))
-			if len(custRules) > 0 {
-				custRuleItem := custRules[0].(map[string]interface{})
-
-				custRule := policy.CustomRule{
-					Id:     custRuleItem["_id"].(int),
-					Action: custRuleItem["action"].([]string),
-					Effect: custRuleItem["effect"].(string),
-				}
-				rule.CustomRules = append(rule.CustomRules, custRule)
-			}
-		}
-		if item["disabled"] != nil {
-			rule.Disabled = item["disabled"].(bool)
-		}
-		if item["filesystem"] != nil {
-			fileSysSet := item["filesystem"].(interface{})
-			fileSysItem := fileSysSet.(map[string]interface{})
-
-			rule.Filesystem = policy.Filesystem{}
-			if fileSysItem["blacklist"] != nil {
-				rule.Filesystem.BackdoorFiles = fileSysItem["backdoorFiles"].(bool)
-			}
-			if fileSysItem["blacklist"] != nil {
-				rule.Filesystem.Blacklist = fileSysItem["blacklist"].([]string)
-			}
-			if fileSysItem["checkNewFiles"] != nil {
-				rule.Filesystem.CheckNewFiles = fileSysItem["checkNewFiles"].(bool)
-			}
-			if fileSysItem["effect"] != nil {
-				rule.Filesystem.Effect = fileSysItem["effect"].(string)
-			}
-			if fileSysItem["skipEncryptedBinaries"] != nil {
-				rule.Filesystem.SkipEncryptedBinaries = fileSysItem["skipEncryptedBinaries"].(bool)
-			}
-			if fileSysItem["suspiciousELFHeaders"] != nil {
-				rule.Filesystem.SuspiciousELFHeaders = fileSysItem["suspiciousELFHeaders"].(bool)
-			}
-			if fileSysItem["whitelist"] != nil {
-				rule.Filesystem.Whitelist = fileSysItem["whitelist"].([]string)
-			}
-		}
-		if item["kubernetesenforcement"] != nil {
-			rule.KubernetesEnforcement = item["kubernetesenforcement"].(bool)
-		}
-		if item["modified"] != nil {
-			rule.Modified = item["modified"].(string)
-		}
-		if item["name"] != nil {
-			rule.Name = item["name"].(string)
-		}
-		if item["network"] != nil {
-			networkSet := item["network"].(interface{})
-			networkItem := networkSet.(map[string]interface{})
-			if networkItem["blacklistIPs"] != nil {
-				rule.Network.BlacklistIPs = networkItem["blacklistIPs"].([]string)
-			}
-
-			if networkItem["blacklistListeningPorts"] != nil {
-				blacklistListenPorts := networkItem["blacklistListeningPorts"].([]interface{})
-				rule.Network.BlacklistListeningPorts = make([]policy.ListPort, 0, len(blacklistListenPorts))
-				if len(blacklistListenPorts) > 0 {
-					rule.Network.BlacklistListeningPorts = append(rule.Network.BlacklistListeningPorts, getListPort(blacklistListenPorts[0]))
+					rule.Collections = append(rule.Collections, getCollection(collItem))
 				}
 			}
+			if item["condition"] != nil {
+				cond := item["condition"].(map[string]interface{})
 
-			if networkItem["blacklistOutboundPorts"] != nil {
-				blacklistOutPorts := networkItem["blacklistOutboundPorts"].([]interface{})
-				rule.Network.BlacklistOutboundPorts = make([]policy.ListPort, 0, len(blacklistOutPorts))
-				if len(blacklistOutPorts) > 0 {
-					rule.Network.BlacklistOutboundPorts = append(rule.Network.BlacklistOutboundPorts, getListPort(blacklistOutPorts[0]))
+				condition := policy.Condition{}
+
+				if cond["vulnerabilities"] != nil {
+					vuln := cond["vulnerabilities"].(map[string]interface{})
+					vulnerabilities := policy.Vulnerability{
+						Block:       vuln["block"].(bool),
+						Id:          vuln["id"].(int),
+						MinSeverity: vuln["minSeverity"].(int),
+					}
+					condition.Vulnerabilities = append(condition.Vulnerabilities, vulnerabilities)
 				}
 			}
-			if networkItem["blacklistOutboundPorts"] != nil {
-				rule.Network.DetectPortScan = networkItem["detectPortScan"].(bool)
-			}
-			if networkItem["effect"] != nil {
-				rule.Network.Effect = networkItem["effect"].(string)
-			}
-			if networkItem["skipModifiedProc"] != nil {
-				rule.Network.SkipModifiedProc = networkItem["skipModifiedProc"].(bool)
-			}
-			if networkItem["skipRawSockets"] != nil {
-				rule.Network.SkipRawSockets = networkItem["skipRawSockets"].(bool)
-			}
-			if networkItem["whitelistIPs"] != nil {
-				rule.Network.WhitelistIPs = networkItem["whitelistIPs"].([]string)
-			}
+			if item["customrules"] != nil {
+				custRules := item["customrules"].([]interface{})
+				rule.CustomRules = make([]policy.CustomRule, 0, len(custRules))
+				if len(custRules) > 0 {
+					custRuleItem := custRules[0].(map[string]interface{})
 
-			if networkItem["whitelistListeningPorts"] != nil {
-				whitelistListenPorts := networkItem["whitelistListeningPorts"].([]interface{})
-				rule.Network.WhitelistListeningPorts = make([]policy.ListPort, 0, len(whitelistListenPorts))
-				if len(whitelistListenPorts) > 0 {
-					rule.Network.WhitelistListeningPorts = append(rule.Network.WhitelistListeningPorts, getListPort(whitelistListenPorts[0]))
+					custRule := policy.CustomRule{
+						Id:     custRuleItem["_id"].(int),
+						Action: custRuleItem["action"].([]string),
+						Effect: custRuleItem["effect"].(string),
+					}
+					rule.CustomRules = append(rule.CustomRules, custRule)
 				}
 			}
+			if item["disabled"] != nil {
+				rule.Disabled = item["disabled"].(bool)
+			}
+			if item["filesystem"] != nil {
+				fileSysSet := item["filesystem"].(interface{})
+				fileSysItem := fileSysSet.(map[string]interface{})
 
-			if networkItem["whitelistOutboundPorts"] != nil {
-				whitelistOutPorts := networkItem["whitelistOutboundPorts"].([]interface{})
-				rule.Network.WhitelistOutboundPorts = make([]policy.ListPort, 0, len(whitelistOutPorts))
-				if len(whitelistOutPorts) > 0 {
-					rule.Network.WhitelistOutboundPorts = append(rule.Network.WhitelistOutboundPorts, getListPort(whitelistOutPorts[0]))
+				rule.Filesystem = policy.Filesystem{}
+				if fileSysItem["blacklist"] != nil {
+					rule.Filesystem.BackdoorFiles = fileSysItem["backdoorFiles"].(bool)
+				}
+				if fileSysItem["blacklist"] != nil {
+					rule.Filesystem.Blacklist = fileSysItem["blacklist"].([]string)
+				}
+				if fileSysItem["checkNewFiles"] != nil {
+					rule.Filesystem.CheckNewFiles = fileSysItem["checkNewFiles"].(bool)
+				}
+				if fileSysItem["effect"] != nil {
+					rule.Filesystem.Effect = fileSysItem["effect"].(string)
+				}
+				if fileSysItem["skipEncryptedBinaries"] != nil {
+					rule.Filesystem.SkipEncryptedBinaries = fileSysItem["skipEncryptedBinaries"].(bool)
+				}
+				if fileSysItem["suspiciousELFHeaders"] != nil {
+					rule.Filesystem.SuspiciousELFHeaders = fileSysItem["suspiciousELFHeaders"].(bool)
+				}
+				if fileSysItem["whitelist"] != nil {
+					rule.Filesystem.Whitelist = fileSysItem["whitelist"].([]string)
 				}
 			}
-		}
-		if item["notes"] != nil {
-			rule.Notes = item["notes"].(string)
-		}
-		if item["owner"] != nil {
-			rule.Owner = item["owner"].(string)
-		}
-		if item["previousname"] != nil {
-			rule.PreviousName = item["previousname"].(string)
-		}
-		if item["processes"] != nil {
-			processSet := item["processes"].(interface{})
-			processItem := processSet.(map[string]interface{})
+			if item["kubernetesenforcement"] != nil {
+				rule.KubernetesEnforcement = item["kubernetesenforcement"].(bool)
+			}
+			if item["modified"] != nil {
+				rule.Modified = item["modified"].(string)
+			}
+			if item["name"] != nil {
+				rule.Name = item["name"].(string)
+			}
+			if item["network"] != nil {
+				networkSet := item["network"].(interface{})
+				networkItem := networkSet.(map[string]interface{})
+				if networkItem["blacklistIPs"] != nil {
+					rule.Network.BlacklistIPs = networkItem["blacklistIPs"].([]string)
+				}
 
-			rule.Processes = policy.Processes{}
+				if networkItem["blacklistListeningPorts"] != nil {
+					blacklistListenPorts := networkItem["blacklistListeningPorts"].([]interface{})
+					rule.Network.BlacklistListeningPorts = make([]policy.ListPort, 0, len(blacklistListenPorts))
+					if len(blacklistListenPorts) > 0 {
+						rule.Network.BlacklistListeningPorts = append(rule.Network.BlacklistListeningPorts, getListPort(blacklistListenPorts[0]))
+					}
+				}
 
-			if processItem["blacklist"] != nil {
-				rule.Processes.Blacklist = processItem["blacklist"].([]string)
-			}
-			if processItem["blockAllBinaries"] != nil {
-				rule.Processes.BlockAllBinaries = processItem["blockAllBinaries"].(bool)
-			}
-			if processItem["checkCryptoMiners"] != nil {
-				rule.Processes.CheckCryptoMiners = processItem["checkCryptoMiners"].(bool)
-			}
-			if processItem["checkLateralMovement"] != nil {
-				rule.Processes.CheckLateralMovement = processItem["checkLateralMovement"].(bool)
-			}
-			if processItem["checkNewBinaries"] != nil {
-				rule.Processes.CheckNewBinaries = processItem["checkNewBinaries"].(bool)
-			}
-			if processItem["checkParentChild"] != nil {
-				rule.Processes.CheckParentChild = processItem["checkParentChild"].(bool)
-			}
-			if processItem["checkSuidBinaries"] != nil {
-				rule.Processes.CheckSuidBinaries = processItem["checkSuidBinaries"].(bool)
-			}
-			if processItem["effect"] != nil {
-				rule.Processes.Effect = processItem["effect"].(string)
-			}
-			if processItem["skipModified"] != nil {
-				rule.Processes.SkipModified = processItem["skipModified"].(bool)
-			}
-			if processItem["skipReverseShell"] != nil {
-				rule.Processes.SkipReverseShell = processItem["skipReverseShell"].(bool)
-			}
-			if processItem["whitelist"] != nil {
-				rule.Processes.Whitelist = processItem["whitelist"].([]string)
-			}
-		}
-		if item["wildfireanalysis"] != nil {
-			rule.WildFireAnalysis = item["wildfireanalysis"].(string)
-		}
+				if networkItem["blacklistOutboundPorts"] != nil {
+					blacklistOutPorts := networkItem["blacklistOutboundPorts"].([]interface{})
+					rule.Network.BlacklistOutboundPorts = make([]policy.ListPort, 0, len(blacklistOutPorts))
+					if len(blacklistOutPorts) > 0 {
+						rule.Network.BlacklistOutboundPorts = append(rule.Network.BlacklistOutboundPorts, getListPort(blacklistOutPorts[0]))
+					}
+				}
+				if networkItem["blacklistOutboundPorts"] != nil {
+					rule.Network.DetectPortScan = networkItem["detectPortScan"].(bool)
+				}
+				if networkItem["effect"] != nil {
+					rule.Network.Effect = networkItem["effect"].(string)
+				}
+				if networkItem["skipModifiedProc"] != nil {
+					rule.Network.SkipModifiedProc = networkItem["skipModifiedProc"].(bool)
+				}
+				if networkItem["skipRawSockets"] != nil {
+					rule.Network.SkipRawSockets = networkItem["skipRawSockets"].(bool)
+				}
+				if networkItem["whitelistIPs"] != nil {
+					rule.Network.WhitelistIPs = networkItem["whitelistIPs"].([]string)
+				}
 
-		ans.Rules = append(ans.Rules, rule)
+				if networkItem["whitelistListeningPorts"] != nil {
+					whitelistListenPorts := networkItem["whitelistListeningPorts"].([]interface{})
+					rule.Network.WhitelistListeningPorts = make([]policy.ListPort, 0, len(whitelistListenPorts))
+					if len(whitelistListenPorts) > 0 {
+						rule.Network.WhitelistListeningPorts = append(rule.Network.WhitelistListeningPorts, getListPort(whitelistListenPorts[0]))
+					}
+				}
+
+				if networkItem["whitelistOutboundPorts"] != nil {
+					whitelistOutPorts := networkItem["whitelistOutboundPorts"].([]interface{})
+					rule.Network.WhitelistOutboundPorts = make([]policy.ListPort, 0, len(whitelistOutPorts))
+					if len(whitelistOutPorts) > 0 {
+						rule.Network.WhitelistOutboundPorts = append(rule.Network.WhitelistOutboundPorts, getListPort(whitelistOutPorts[0]))
+					}
+				}
+			}
+			if item["notes"] != nil {
+				rule.Notes = item["notes"].(string)
+			}
+			if item["owner"] != nil {
+				rule.Owner = item["owner"].(string)
+			}
+			if item["previousname"] != nil {
+				rule.PreviousName = item["previousname"].(string)
+			}
+			if item["processes"] != nil {
+				processSet := item["processes"].(interface{})
+				processItem := processSet.(map[string]interface{})
+
+				rule.Processes = policy.Processes{}
+
+				if processItem["blacklist"] != nil {
+					rule.Processes.Blacklist = processItem["blacklist"].([]string)
+				}
+				if processItem["blockAllBinaries"] != nil {
+					rule.Processes.BlockAllBinaries = processItem["blockAllBinaries"].(bool)
+				}
+				if processItem["checkCryptoMiners"] != nil {
+					rule.Processes.CheckCryptoMiners = processItem["checkCryptoMiners"].(bool)
+				}
+				if processItem["checkLateralMovement"] != nil {
+					rule.Processes.CheckLateralMovement = processItem["checkLateralMovement"].(bool)
+				}
+				if processItem["checkNewBinaries"] != nil {
+					rule.Processes.CheckNewBinaries = processItem["checkNewBinaries"].(bool)
+				}
+				if processItem["checkParentChild"] != nil {
+					rule.Processes.CheckParentChild = processItem["checkParentChild"].(bool)
+				}
+				if processItem["checkSuidBinaries"] != nil {
+					rule.Processes.CheckSuidBinaries = processItem["checkSuidBinaries"].(bool)
+				}
+				if processItem["effect"] != nil {
+					rule.Processes.Effect = processItem["effect"].(string)
+				}
+				if processItem["skipModified"] != nil {
+					rule.Processes.SkipModified = processItem["skipModified"].(bool)
+				}
+				if processItem["skipReverseShell"] != nil {
+					rule.Processes.SkipReverseShell = processItem["skipReverseShell"].(bool)
+				}
+				if processItem["whitelist"] != nil {
+					rule.Processes.Whitelist = processItem["whitelist"].([]string)
+				}
+			}
+			if item["wildfireanalysis"] != nil {
+				rule.WildFireAnalysis = item["wildfireanalysis"].(string)
+			}
+
+			ans.Rules = append(ans.Rules, rule)
+		}
 	}
 
 	return ans


### PR DESCRIPTION
## Description

As mentioned in #12, there is certain limitations in the current policy resources - they can only be created with 1 rule per policy.

The following PR adds logic to allow multiple rules per policy, by iterating over the rules as the policies are getting parsed. I didn't change core logic of how policies are getting parsed, and all the changes are scoped to adding the iteration element.

I updated one of the examples to showcase the policy with multiple rules.

## Motivation and Context

Need to have multiple rules per policy.

## How Has This Been Tested?

Manually tested on self-hosted Prisma Cloud Compute 21.04 running Terraform with various combination of rules.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
