### PR TITLE
Missing provider and creds examples

### DIFF
--- a/examples/provider/creds.json
+++ b/examples/provider/creds.json
@@ -1,0 +1,5 @@
+{
+  "console_url": "https://foo.bar.com",
+  "username": "myUsername",
+  "password": "myPassword"
+}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    prismacloudcompute = {
+      source  = "PaloAltoNetworks/prismacloudcompute"
+      version = "0.1.0"
+    }
+  }
+}
+
 provider "prismacloudcompute" {
   config_file = "creds.json"
 }


### PR DESCRIPTION
## Description

The examples and documentation do not currently include the provider statement for using the provider from the terraform registry.  The documentation also states to refer to examples/creds.json, but the file doesn't exist.

## Motivation and Context

Provide examples and documentation for using provider from registry

## How Has This Been Tested?

Currently using 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes if appropriate.
- [x ] All new and existing tests passed.
