### PR TITLE
Add admission policy resource

### DIFF
--- a/prismacloudcompute/common.go
+++ b/prismacloudcompute/common.go
@@ -1,6 +1,7 @@
 package prismacloudcompute
 
 const (
+	policyTypeAdmission            = "admission"
 	policyTypeComplianceCiImage    = "ciImagesCompliance"
 	policyTypeComplianceContainer  = "containerCompliance"
 	policyTypeComplianceHost       = "hostCompliance"

--- a/prismacloudcompute/convert/admission.go
+++ b/prismacloudcompute/convert/admission.go
@@ -1,0 +1,40 @@
+package convert
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/policy"
+)
+
+func SchemaToAdmissionRules(d *schema.ResourceData) ([]policy.AdmissionRule, error) {
+	parsedRules := make([]policy.AdmissionRule, 0)
+	if rules, ok := d.GetOk("rule"); ok {
+		presentRules := rules.([]interface{})
+		for _, val := range presentRules {
+			presentRule := val.(map[string]interface{})
+			parsedRule := policy.AdmissionRule{}
+
+			parsedRule.Description = presentRule["description"].(string)
+			parsedRule.Disabled = presentRule["disabled"].(bool)
+			parsedRule.Effect = presentRule["effect"].(string)
+			parsedRule.Name = presentRule["name"].(string)
+			parsedRule.Script = presentRule["script"].(string)
+
+			parsedRules = append(parsedRules, parsedRule)
+		}
+	}
+	return parsedRules, nil
+}
+
+func AdmissionRulesToSchema(in []policy.AdmissionRule) []interface{} {
+	ans := make([]interface{}, 0, len(in))
+	for _, val := range in {
+		m := make(map[string]interface{})
+		m["description"] = val.Description
+		m["disabled"] = val.Disabled
+		m["effect"] = val.Effect
+		m["name"] = val.Name
+		m["script"] = val.Script
+		ans = append(ans, m)
+	}
+	return ans
+}

--- a/prismacloudcompute/provider.go
+++ b/prismacloudcompute/provider.go
@@ -48,6 +48,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"prismacloudcompute_collection":                    resourceCollection(),
+			"prismacloudcompute_admission_policy":              resourcePoliciesAdmission(),
 			"prismacloudcompute_ci_image_compliance_policy":    resourcePoliciesComplianceCiImage(),
 			"prismacloudcompute_container_compliance_policy":   resourcePoliciesComplianceContainer(),
 			"prismacloudcompute_host_compliance_policy":        resourcePoliciesComplianceHost(),

--- a/prismacloudcompute/resource_credentials_test.go
+++ b/prismacloudcompute/resource_credentials_test.go
@@ -92,7 +92,7 @@ func TestCredentialsAuditEvent(t *testing.T) {
 }
 
 func testCredentialsExists(n string, o *group.Group) resource.TestCheckFunc {
-return func(s *terraform.State) error {
+	return func(s *terraform.State) error {
 		// return fmt.Errorf("What is the name: %s", o.GroupId)
 
 		rs, ok := s.RootModule().Resources[n]

--- a/prismacloudcompute/resource_groups_test.go
+++ b/prismacloudcompute/resource_groups_test.go
@@ -92,7 +92,7 @@ func TestGroupsAuditEvent(t *testing.T) {
 }
 
 func testGroupsExists(n string, o *group.Group) resource.TestCheckFunc {
-return func(s *terraform.State) error {
+	return func(s *terraform.State) error {
 		// return fmt.Errorf("What is the name: %s", o.GroupId)
 
 		rs, ok := s.RootModule().Resources[n]

--- a/prismacloudcompute/resource_policies_admission.go
+++ b/prismacloudcompute/resource_policies_admission.go
@@ -1,0 +1,125 @@
+package prismacloudcompute
+
+import (
+	"fmt"
+
+	"github.com/PaloAltoNetworks/terraform-provider-prismacloudcompute/prismacloudcompute/convert"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/pcc"
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/policy"
+)
+
+func resourcePoliciesAdmission() *schema.Resource {
+	return &schema.Resource{
+		Create: createPolicyAdmission,
+		Read:   readPolicyAdmission,
+		Update: updatePolicyAdmission,
+		Delete: deletePolicyAdmission,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of the policy.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"rule": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Rules that make up the policy.",
+				MinItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Free-form text field.",
+						},
+						"disabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Whether or not to disable the rule.",
+						},
+						"effect": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Uhe effect to be used. Can be set to 'allow', 'block' or 'alert'.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Unique name of the rule.",
+						},
+						"script": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Policy script in Rego syntax.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createPolicyAdmission(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pcc.Client)
+	parsedRules, err := convert.SchemaToAdmissionRules(d)
+
+	if err != nil {
+		return fmt.Errorf("error creating %s policy: %s", policyTypeAdmission, err)
+	}
+
+	parsedPolicy := policy.AdmissionPolicy{
+		Id:    policyTypeAdmission,
+		Rules: parsedRules,
+	}
+
+	if err := policy.UpdateAdmission(*client, parsedPolicy); err != nil {
+		return fmt.Errorf("error creating %s policy: %s", policyTypeAdmission, err)
+	}
+
+	d.SetId(policyTypeAdmission)
+	return readPolicyAdmission(d, meta)
+}
+
+func readPolicyAdmission(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pcc.Client)
+	retrievedPolicy, err := policy.GetAdmission(*client)
+	if err != nil {
+		return fmt.Errorf("error reading %s policy: %s", policyTypeAdmission, err)
+	}
+
+	if err := d.Set("rule", convert.AdmissionRulesToSchema(retrievedPolicy.Rules)); err != nil {
+		return fmt.Errorf("error reading %s policy: %s", policyTypeAdmission, err)
+	}
+
+	return nil
+}
+
+func updatePolicyAdmission(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pcc.Client)
+	parsedRules, err := convert.SchemaToAdmissionRules(d)
+	if err != nil {
+		return fmt.Errorf("error updating %s policy: %s", policyTypeAdmission, err)
+	}
+
+	parsedPolicy := policy.AdmissionPolicy{
+		Id:    policyTypeAdmission,
+		Rules: parsedRules,
+	}
+
+	if err := policy.UpdateAdmission(*client, parsedPolicy); err != nil {
+		return fmt.Errorf("error updating %s policy: %s", policyTypeAdmission, err)
+	}
+
+	return readPolicyAdmission(d, meta)
+}
+
+func deletePolicyAdmission(d *schema.ResourceData, meta interface{}) error {
+	// TODO: reset to default policy
+	return nil
+}

--- a/prismacloudcompute/resource_policies_admission_test.go
+++ b/prismacloudcompute/resource_policies_admission_test.go
@@ -1,0 +1,169 @@
+package prismacloudcompute
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/pcc"
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/policy"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccPolicyAdmissionConfig(t *testing.T) {
+	fmt.Printf("\n\nStart TestAccPolicyAdmissionConfig")
+	var o policy.Policy
+	id := fmt.Sprintf("tf%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccPolicyAdmissionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyAdmissionConfig(id),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyAdmissionExists("prismacloudcompute_policies_admission.test", &o),
+					testAccCheckPolicyAdmissionAttributes(&o, id, true),
+				),
+			},
+			{
+				Config: testAccPolicyAdmissionConfig(id),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyAdmissionExists("prismacloudcompute_policies_admission.test", &o),
+					testAccCheckPolicyAdmissionAttributes(&o, id, true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPolicyAdmissionNetwork(t *testing.T) {
+	var o policy.Policy
+	id := fmt.Sprintf("tf%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccPolicyAdmissionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyAdmissionConfig(id),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyAdmissionExists("prismacloudcompute_policies_admission.test", &o),
+					testAccCheckPolicyAdmissionAttributes(&o, id, true),
+				),
+			},
+			{
+				Config: testAccPolicyAdmissionConfig(id),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyAdmissionExists("prismacloudcompute_policies_admission.test", &o),
+					testAccCheckPolicyAdmissionAttributes(&o, id, true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPolicyAdmissionAuditEvent(t *testing.T) {
+	var o policy.Policy
+	id := fmt.Sprintf("tf%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccPolicyAdmissionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyAdmissionConfig(id),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyAdmissionExists("prismacloudcompute_policies_admission.test", &o),
+					testAccCheckPolicyAdmissionAttributes(&o, id, true),
+				),
+			},
+			{
+				Config: testAccPolicyAdmissionConfig(id),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyAdmissionExists("prismacloudcompute_policies_admission.test", &o),
+					testAccCheckPolicyAdmissionAttributes(&o, id, true),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPolicyAdmissionExists(n string, o *policy.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// return fmt.Errorf("What is the name: %s", o.PolicyId)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Object label Id is not set")
+		}
+
+		client := testAccProvider.Meta().(*pcc.Client)
+		lo, err := policy.Get(*client, policy.ComplianceHostEndpoint)
+		if err != nil {
+			return fmt.Errorf("Error in get: %s", err)
+		}
+		*o = lo
+
+		return nil
+	}
+}
+
+func testAccCheckPolicyAdmissionAttributes(o *policy.Policy, id string, policyType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if o.PolicyId != id {
+			return fmt.Errorf("\n\nPolicyId is %s, expected %s", o.PolicyId, id)
+		} else {
+			fmt.Printf("\n\nName is %s", o.PolicyId)
+		}
+
+		if o.PolicyType != policyType {
+			return fmt.Errorf("PolicyType is %s, expected %s", o.PolicyType, policyType)
+		}
+
+		return nil
+	}
+}
+
+func testAccPolicyAdmissionDestroy(s *terraform.State) error {
+	/*	client := testAccProvider.Meta().(*pcc.Client)
+
+		for _, rs := range s.RootModule().Resources {
+
+			if rs.Type != "prismacloudcompute_policyadmission" {
+				continue
+			}
+
+			if rs.Primary.ID != "" {
+				name := rs.Primary.ID
+				if err := policy.Delete(client, name); err == nil {
+					return fmt.Errorf("Object %q still exists", name)
+				}
+			}
+			return nil
+		}
+	*/
+	return nil
+}
+
+func testAccPolicyAdmissionConfig(id string) string {
+	var buf bytes.Buffer
+	buf.Grow(500)
+
+	buf.WriteString(fmt.Sprintf(`
+resource "prismacloudcompute_policyAdmission" "test" {
+    name = %q
+}`, id))
+
+	return buf.String()
+}

--- a/prismacloudcompute/resource_rbac_roles_test.go
+++ b/prismacloudcompute/resource_rbac_roles_test.go
@@ -92,7 +92,7 @@ func TestRbacRolesAuditEvent(t *testing.T) {
 }
 
 func testRbacRolesExists(n string, o *group.Group) resource.TestCheckFunc {
-return func(s *terraform.State) error {
+	return func(s *terraform.State) error {
 		// return fmt.Errorf("What is the name: %s", o.GroupId)
 
 		rs, ok := s.RootModule().Resources[n]

--- a/prismacloudcompute/resource_users_test.go
+++ b/prismacloudcompute/resource_users_test.go
@@ -92,7 +92,7 @@ func TestUsersAuditEvent(t *testing.T) {
 }
 
 func testUsersExists(n string, o *user.User) resource.TestCheckFunc {
-return func(s *terraform.State) error {
+	return func(s *terraform.State) error {
 		// return fmt.Errorf("What is the name: %s", o.UserId)
 
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
## Description

Add feature requested in #32 

## Motivation and Context

Rego policies would be nice to manage using Terraform 😃 

Now you can do the following:

```hcl

resource "prismacloudcompute_admission_policy" "ruleset" {
  rule {
    name        = "Block host PID and IPC sharing"
    disabled    = true
    effect      = "block"
    description = "This rule is important, but disabled"
    script      = <<-EOT
            match[{"msg": msg}] {
            	input.request.operation == "CREATE"
            	input.request.kind.kind == "Pod"
            	input.request.resource.resource == "pods"
            	input_share_hostnamespace(input.request.object)
            	msg := sprintf("Sharing the host namespace is not allowed, pod: %v", [input.request.object.metadata.name])
            }

            input_share_hostnamespace(o) {
                o.spec.hostPID
            }

            input_share_hostnamespace(o) {
                o.spec.hostIPC
            }
        EOT
  }
  rule {
    name        = "Allow containers with non read only filesystem"
    disabled    = false
    effect      = "allow"
    description = "This rule is important and enabled, but allowed"
    script      = <<-EOT
            match[{"msg": msg}] {
                operations := {"CREATE"}
                operations[input.request.operation]
                input.request.kind.kind == "Pod"

                containers := input.request.object.spec.containers[_]

                not containers.securityContext.readOnlyRootFilesystem
                msg := sprintf("container '%v' does not have a read only root filesystem", [containers.name])
            }
        EOT
  }
}
```

## How Has This Been Tested?

With Prisma Cloud Console 21.08

It depends on https://github.com/PaloAltoNetworks/prisma-cloud-compute-go/pull/26

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
