### PR TITLE
Add resource for custom rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,5 @@ require (
 	google.golang.org/grpc v1.32.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 )
+
+replace github.com/paloaltonetworks/prisma-cloud-compute-go => /Users/aakatev/Documents/personal/prisma-cloud-compute-go

--- a/go.mod
+++ b/go.mod
@@ -69,5 +69,3 @@ require (
 	google.golang.org/grpc v1.32.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 )
-
-replace github.com/paloaltonetworks/prisma-cloud-compute-go => /Users/aakatev/Documents/personal/prisma-cloud-compute-go

--- a/prismacloudcompute/convert/custom_rule.go
+++ b/prismacloudcompute/convert/custom_rule.go
@@ -24,5 +24,8 @@ func SchemaToCustomRule(d *schema.ResourceData) rule.CustomRule {
 	if val, ok := d.GetOk("type"); ok {
 		parsedRule.Type = val.(string)
 	}
+	if val, ok := d.GetOk("prisma_id"); ok {
+		parsedRule.Id = val.(int)
+	}
 	return parsedRule
 }

--- a/prismacloudcompute/convert/custom_rule.go
+++ b/prismacloudcompute/convert/custom_rule.go
@@ -1,0 +1,28 @@
+package convert
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/rule"
+)
+
+// Converts a custom rule schema to a custom rule object for SDK compatibility.
+func SchemaToCustomRule(d *schema.ResourceData) rule.CustomRule {
+	parsedRule := rule.CustomRule{}
+
+	if val, ok := d.GetOk("description"); ok {
+		parsedRule.Description = val.(string)
+	}
+	if val, ok := d.GetOk("message"); ok {
+		parsedRule.Message = val.(string)
+	}
+	if val, ok := d.GetOk("name"); ok {
+		parsedRule.Name = val.(string)
+	}
+	if val, ok := d.GetOk("script"); ok {
+		parsedRule.Script = val.(string)
+	}
+	if val, ok := d.GetOk("type"); ok {
+		parsedRule.Type = val.(string)
+	}
+	return parsedRule
+}

--- a/prismacloudcompute/provider.go
+++ b/prismacloudcompute/provider.go
@@ -48,6 +48,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"prismacloudcompute_collection":                    resourceCollection(),
+			"prismacloudcompute_custom_rule":                   resourceCustomRule(),
 			"prismacloudcompute_admission_policy":              resourcePoliciesAdmission(),
 			"prismacloudcompute_ci_image_compliance_policy":    resourcePoliciesComplianceCiImage(),
 			"prismacloudcompute_container_compliance_policy":   resourcePoliciesComplianceContainer(),

--- a/prismacloudcompute/resource_custom_rule.go
+++ b/prismacloudcompute/resource_custom_rule.go
@@ -1,0 +1,126 @@
+package prismacloudcompute
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/PaloAltoNetworks/terraform-provider-prismacloudcompute/prismacloudcompute/convert"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/pcc"
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/rule"
+)
+
+func resourceCustomRule() *schema.Resource {
+	return &schema.Resource{
+		Create: createCustomRule,
+		Read:   readCustomRule,
+		Update: updateCustomRule,
+		Delete: deleteCustomRule,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of the custom rule.",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A free-form text description of the custom rule.",
+			},
+			"message": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Message to display for a custom rule event.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A unique custom rule name.",
+			},
+			"script": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "An custom rule expression.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The custom rule type. Can be set to 'processes', 'filesystem', 'network-outgoing', 'kubernetes-audit', 'waas-request', 'waas-response'",
+			},
+		},
+	}
+}
+
+func createCustomRule(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pcc.Client)
+	parsedCustomRule := convert.SchemaToCustomRule(d)
+	if err := rule.CreateCustomRule(*client, parsedCustomRule); err != nil {
+		return fmt.Errorf("error creating custom rule '%+v': %s", parsedCustomRule, err)
+	}
+
+	d.SetId(strconv.Itoa(parsedCustomRule.Id))
+	return readCustomRule(d, meta)
+}
+
+func readCustomRule(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pcc.Client)
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("error reading custom rule: %s", err)
+	}
+	retrievedCustomRule, err := rule.GetCustomRule(*client, id)
+	if err != nil {
+		return fmt.Errorf("error reading custom rule: %s", err)
+	}
+
+	if err := d.Set("description", retrievedCustomRule.Description); err != nil {
+		return fmt.Errorf("error reading custom rule: %s", err)
+	}
+	if err := d.Set("id", retrievedCustomRule.Id); err != nil {
+		return fmt.Errorf("error reading custom rule: %s", err)
+	}
+	if err := d.Set("message", retrievedCustomRule.Message); err != nil {
+		return fmt.Errorf("error reading custom rule: %s", err)
+	}
+	if err := d.Set("name", retrievedCustomRule.Name); err != nil {
+		return fmt.Errorf("error reading custom rule: %s", err)
+	}
+	if err := d.Set("script", retrievedCustomRule.Script); err != nil {
+		return fmt.Errorf("error reading custom rule: %s", err)
+	}
+	if err := d.Set("type", retrievedCustomRule.Type); err != nil {
+		return fmt.Errorf("error reading custom rule: %s", err)
+	}
+
+	return nil
+}
+
+func updateCustomRule(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pcc.Client)
+	parsedCustomRule := convert.SchemaToCustomRule(d)
+
+	if err := rule.UpdateCustomRule(*client, parsedCustomRule); err != nil {
+		return fmt.Errorf("error updating custom rule: %s", err)
+	}
+
+	return readCustomRule(d, meta)
+}
+
+func deleteCustomRule(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pcc.Client)
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("error reading custom rule: %s", err)
+	}
+	if err := rule.DeleteCustomRule(*client, id); err != nil {
+		return fmt.Errorf("error updating custom rule '%s': %s", d.Id(), err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/prismacloudcompute/resource_custom_rule_test.go
+++ b/prismacloudcompute/resource_custom_rule_test.go
@@ -1,0 +1,174 @@
+package prismacloudcompute
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/pcc"
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/rule"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccCustomRuleConfig(t *testing.T) {
+	fmt.Printf("\n\nStart TestAccCustomRuleConfig")
+	var o rule.CustomRule
+	name := fmt.Sprintf("tf%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCustomRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomRuleConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomRuleExists("prismacloudcompute_custom_rule.test", &o),
+					testAccCheckCustomRuleAttributes(&o, name, "description", "#000000"),
+				),
+			},
+			{
+				Config: testAccCustomRuleConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomRuleExists("prismacloudcompute_custom_rule.test", &o),
+					testAccCheckCustomRuleAttributes(&o, name, "description", "#000000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCustomRuleNetwork(t *testing.T) {
+	var o rule.CustomRule
+	name := fmt.Sprintf("tf%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCustomRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomRuleConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomRuleExists("prismacloudcompute_custom_rule.test", &o),
+					testAccCheckCustomRuleAttributes(&o, name, "description", "#000000"),
+				),
+			},
+			{
+				Config: testAccCustomRuleConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomRuleExists("prismacloudcompute_custom_rule.test", &o),
+					testAccCheckCustomRuleAttributes(&o, name, "description", "#000000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCustomRuleAuditEvent(t *testing.T) {
+	var o rule.CustomRule
+	name := fmt.Sprintf("tf%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCustomRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomRuleConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomRuleExists("prismacloudcompute_custom_rule.test", &o),
+					testAccCheckCustomRuleAttributes(&o, name, "description", "#000000"),
+				),
+			},
+			{
+				Config: testAccCustomRuleConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomRuleExists("prismacloudcompute_custom_rule.test", &o),
+					testAccCheckCustomRuleAttributes(&o, name, "description", "#000000"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCustomRuleExists(n string, o *rule.CustomRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// return fmt.Errorf("What is the name: %s", o.Name)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Object label Name is not set")
+		}
+
+		client := testAccProvider.Meta().(*pcc.Client)
+		name := rs.Primary.ID
+		lo, err := rule.Get(*client, name)
+		if err != nil {
+			return fmt.Errorf("Error in get: %s", err)
+		}
+		o = lo
+
+		return nil
+	}
+}
+
+func testAccCheckCustomRuleAttributes(o *rule.CustomRule, name string, description string, color string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if o.Name != name {
+			return fmt.Errorf("\n\nName is %s, expected %s", o.Name, name)
+		} else {
+			fmt.Printf("\n\nName is %s", o.Name)
+		}
+
+		if o.Description != description {
+			return fmt.Errorf("Description is %s, expected %s", o.Description, description)
+		}
+
+		if o.Color != color {
+			return fmt.Errorf("Color type is %q, expected %q", o.Color, color)
+		}
+
+		return nil
+	}
+}
+
+func testAccCustomRuleDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*pcc.Client)
+
+	for _, rs := range s.RootModule().Resources {
+
+		if rs.Type != "prismacloudcompute_custom_rule" {
+			continue
+		}
+
+		if rs.Primary.ID != "" {
+			name := rs.Primary.ID
+			if err := rule.Delete(*client, name); err == nil {
+				return fmt.Errorf("Object %q still exists", name)
+			}
+		}
+		return nil
+	}
+
+	return nil
+}
+
+func testAccCustomRuleConfig(name string) string {
+	var buf bytes.Buffer
+	buf.Grow(500)
+
+	buf.WriteString(fmt.Sprintf(`
+resource "prismacloudcompute_custom_rules" "test" {
+    name = %q
+}`, name))
+
+	return buf.String()
+}

--- a/prismacloudcompute/resource_policies_admission.go
+++ b/prismacloudcompute/resource_policies_admission.go
@@ -46,7 +46,7 @@ func resourcePoliciesAdmission() *schema.Resource {
 						"effect": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "Uhe effect to be used. Can be set to 'allow', 'block' or 'alert'.",
+							Description: "The effect to be used. Can be set to 'allow', 'block' or 'alert'.",
 						},
 						"name": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
## Description

Add custom rules resource to provider. This requires an update to pcc client, tracked by this pr https://github.com/PaloAltoNetworks/prisma-cloud-compute-go/pull/27

## Motivation and Context

This feature is requested in #29 

## How Has This Been Tested?

I used the following resource to test changes:

```hcl

resource "prismacloudcompute_custom_rule" "test" {
  name        = "basic-rule"
  description = "this is basic rule"
  message     = "%proc.name doing stuff"
  type        = "processes"
  script      = "proc.name = \"cat\""
}

resource "prismacloudcompute_custom_rule" "test_heredoc" {
  name        = "less-basic-rule"
  description = "this is less basic rule"
  message     = "%proc.name wrote to path"
  type        = "filesystem"
  script      = <<EOT
                  // Example:
                  // user modifies a sensitive file under /etc or its subfolders
                  // proc.user != "root" and file.path startswith "/etc"

                  proc.user != "crond" and file.path startswith "/var/spool"
                EOT
}

```

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
