### PR TITLE
Fix Typo in Runtime Host Policy

### DIFF
--- a/prismacloudcompute/convert/runtime_host.go
+++ b/prismacloudcompute/convert/runtime_host.go
@@ -108,7 +108,7 @@ func SchemaToRuntimeHostRules(d *schema.ResourceData) ([]policy.RuntimeHostRule,
 				parsedRule.Forensic = policy.RuntimeHostForensic{}
 			}
 
-			presentLogInspectionRules := presentRule["file_integrity_rule"].([]interface{})
+			presentLogInspectionRules := presentRule["log_inspection_rule"].([]interface{})
 			parsedLogInspectionRules := make([]policy.RuntimeHostLogInspectionRule, 0, len(presentLogInspectionRules))
 			for _, val := range presentLogInspectionRules {
 				presentLogInspectionRule := val.(map[string]interface{})


### PR DESCRIPTION
## Description

I noticed that applying policy containing `file_integrity_rule` is causing unexpected crash with v0.2.0. I fixed the typo that seems to cause an issue, but haven't tested to confirm it works just yet.

## Motivation and Context

Fix the bug

## How Has This Been Tested?

Tested v0.2.0 with the following template is causing crash:

```hcl
resource "prismacloudcompute_host_runtime_policy" "ruleset" {
  rule {
    collections = [
      "All",
    ]
    disabled = true
    name     = "Host Security Policy"
    notes    = "Host Security Policy covers FIM rules, Egress Allow list and has anti-malware rules to prevent system abuse/misuse"

    activities {
      disabled                   = false
      docker_enabled             = true
      readonly_docker_enabled    = true
      service_activities_enabled = false
      sshd_enabled               = true
      sudo_enabled               = true
    }

    antimalware {
      allowed_processes = [
        "/var/spool/anacron/cron.daily",
        "/var/spool/anacron/cron.weekly",
        "/var/spool/anacron/cron.monthly",
      ]
      crypto_miners                    = "prevent"
      custom_feed                      = "alert"
      detect_compiler_generated_binary = false
      encrypted_binaries               = "alert"
      execution_flow_hijack            = "alert"
      intelligence_feed                = "alert"
      reverse_shell                    = "alert"
      service_unknown_origin_binary    = "alert"
      skip_ssh_tracking                = false
      suspicious_elf_headers           = "alert"
      temp_filesystem_processes        = "alert"
      user_unknown_origin_binary       = "alert"
      webshell                         = "alert"
      wildfire_analysis                = "alert"

      denied_processes {
        effect = "prevent"
        paths = [
          "yersinia",
        ]
      }
    }

    dns {
      allowed = [
        "*.datadoghq.com",

      ]
      denied            = []
      deny_effect       = "prevent"
      intelligence_feed = "prevent"
    }

    file_integrity_rule {
      allowed_processes = []
      excluded_files    = []
      metadata          = false
      path              = "/etc"
      read              = false
      recursive         = true
      write             = true
    }
    file_integrity_rule {
      allowed_processes = []
      excluded_files    = []
      metadata          = false
      path              = "/sbin"
      read              = false
      recursive         = true
      write             = true
    }
    file_integrity_rule {
      allowed_processes = []
      excluded_files    = []
      metadata          = false
      path              = "/usr/local"
      read              = false
      recursive         = true
      write             = true
    }
    file_integrity_rule {
      allowed_processes = []
      excluded_files    = []
      metadata          = false
      path              = "/bin"
      read              = false
      recursive         = true
      write             = true
    }
    file_integrity_rule {
      allowed_processes = []
      excluded_files    = []
      metadata          = false
      path              = "/usr/sbin"
      read              = false
      recursive         = true
      write             = true
    }
    file_integrity_rule {
      allowed_processes = []
      excluded_files    = []
      metadata          = false
      path              = "/home/*/.ssh/*"
      read              = false
      recursive         = true
      write             = true
    }
    file_integrity_rule {
      allowed_processes = []
      excluded_files    = []
      metadata          = false
      path              = "/usr/bin"
      read              = false
      recursive         = true
      write             = true
    }
    file_integrity_rule {
      allowed_processes = []
      excluded_files    = []
      metadata          = false
      path              = "/boot"
      read              = false
      recursive         = true
      write             = true
    }

    network {
      allowed_outbound_ips = []
      custom_feed          = "alert"
      denied_outbound_ips  = []
      deny_effect          = "alert"
      intelligence_feed    = "alert"
    }
  }
  rule {
    collections = [
      "All",
    ]
    disabled = true
    name     = "Default - alert on suspicious runtime behavior"

    activities {
      disabled                   = false
      docker_enabled             = false
      readonly_docker_enabled    = false
      service_activities_enabled = false
      sshd_enabled               = false
      sudo_enabled               = false
    }

    antimalware {
      allowed_processes                = []
      crypto_miners                    = "alert"
      custom_feed                      = "alert"
      detect_compiler_generated_binary = false
      encrypted_binaries               = "alert"
      execution_flow_hijack            = "alert"
      intelligence_feed                = "alert"
      reverse_shell                    = "alert"
      service_unknown_origin_binary    = "alert"
      skip_ssh_tracking                = false
      suspicious_elf_headers           = "alert"
      temp_filesystem_processes        = "alert"
      user_unknown_origin_binary       = "alert"
      webshell                         = "alert"
      wildfire_analysis                = "alert"

      denied_processes {
        effect = "alert"
        paths  = []
      }
    }

    dns {
      allowed           = []
      denied            = []
      deny_effect       = "disable"
      intelligence_feed = "disable"
    }

    network {
      allowed_outbound_ips = []
      custom_feed          = "alert"
      denied_outbound_ips  = []
      deny_effect          = "alert"
      intelligence_feed    = "alert"
    }
  }
}

```

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
