### PR TITLE
Add Custom Rules Datasource

### DIFF
--- a/prismacloudcompute/data_source_custom_rule.go
+++ b/prismacloudcompute/data_source_custom_rule.go
@@ -1,0 +1,88 @@
+package prismacloudcompute
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/pcc"
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/rule"
+)
+
+func dataSourceCustomRule() *schema.Resource {
+	return &schema.Resource{
+		Description: "Use this data source to retrieve ID of a custom rule.",
+		Read:        dataSourceCustomRuleRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "ID of the custom rule.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"prisma_id": {
+				Description: "Prisma Cloud Compute ID of the custom rule.",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Free-form text description of the custom rule.",
+			},
+			"message": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Message to display for a custom rule event.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique custom rule name.",
+			},
+			"script": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Custom rule expression.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Custom rule type. Can be set to 'processes', 'filesystem', 'network-outgoing', 'kubernetes-audit', 'waas-request', or 'waas-response'.",
+			},
+		},
+	}
+}
+
+func dataSourceCustomRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pcc.Client)
+
+	if name := d.Get("name").(string); name != "" {
+		retrievedCustomRule, err := rule.GetCustomRuleByName(*client, name)
+		if err != nil {
+			return fmt.Errorf("error reading custom rule: %s", err)
+		}
+		if err := d.Set("description", retrievedCustomRule.Description); err != nil {
+			return fmt.Errorf("error reading custom rule: %s", err)
+		}
+		if err := d.Set("prisma_id", retrievedCustomRule.Id); err != nil {
+			return fmt.Errorf("error reading custom rule: %s", err)
+		}
+		if err := d.Set("message", retrievedCustomRule.Message); err != nil {
+			return fmt.Errorf("error reading custom rule: %s", err)
+		}
+		if err := d.Set("name", retrievedCustomRule.Name); err != nil {
+			return fmt.Errorf("error reading custom rule: %s", err)
+		}
+		if err := d.Set("script", retrievedCustomRule.Script); err != nil {
+			return fmt.Errorf("error reading custom rule: %s", err)
+		}
+		if err := d.Set("type", retrievedCustomRule.Type); err != nil {
+			return fmt.Errorf("error reading custom rule: %s", err)
+		}
+		d.SetId(retrievedCustomRule.Name)
+
+		return nil
+	}
+
+	return fmt.Errorf("Missing name parameter")
+}

--- a/prismacloudcompute/data_source_custom_rule_test.go
+++ b/prismacloudcompute/data_source_custom_rule_test.go
@@ -1,0 +1,34 @@
+package prismacloudcompute
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDsCustomRule(t *testing.T) {
+	name := fmt.Sprintf("tf%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDsCustomRule(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.prismacloudcompute_custom_rule.test", "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDsCustomRule(name string) string {
+	return fmt.Sprintf(`
+	data "prismacloudcompute_custom_rule" "test" {
+		name = %q
+	}
+	`, name)
+}

--- a/prismacloudcompute/provider.go
+++ b/prismacloudcompute/provider.go
@@ -65,7 +65,9 @@ func Provider() *schema.Provider {
 			"prismacloudcompute_credential":                    resourceCredentials(),
 		},
 
-		DataSourcesMap: map[string]*schema.Resource{},
+		DataSourcesMap: map[string]*schema.Resource{
+			"prismacloudcompute_custom_rule": dataSourceCustomRule(),
+		},
 
 		ConfigureFunc: configure,
 	}


### PR DESCRIPTION
## Description

Address #37

## Motivation and Context

Inside various policies, Custom Rule IDs look cryptic. It is mainly a concern for rules that aren't "terraformed".

Example:

```hcl
# Some default rules coming with the Console
data "prismacloudcompute_custom_rule" "rule" {
  name = "Twistlock Labs - Suspicious networking tool"
}

data "prismacloudcompute_custom_rule" "another_rule" {
  name = "Twistlock Labs - Running privileged process within container"
}

data "prismacloudcompute_custom_rule" "yet_another_rule" {
  name = "Twistlock Labs - Running cron app"
}

# Add container policy using these custom rules
resource "prismacloudcompute_container_runtime_policy" "ruleset" {
  learning_disabled = false

  rule {
    advanced_protection        = true
    cloud_metadata_enforcement = true
    collections = [
      "All",
    ]
    disabled               = false
    kubernetes_enforcement = true
    name                   = "Demo runtime container policy"
    wildfire_analysis      = "block"

    custom_rule {
      action = "audit"
      effect = "block"
      id     = data.prismacloudcompute_custom_rule.rule.prisma_id
    }
    custom_rule {
      action = "audit"
      effect = "block"
      id     = data.prismacloudcompute_custom_rule.another_rule.prisma_id
    }

    custom_rule {
      action = "audit"
      effect = "block"
      id     = data.prismacloudcompute_custom_rule.yet_another_rule.prisma_id
    }

    dns {
      allowed = [
        "amplitutude.com",
      ]
      denied = [
        "ru.com",
        "cn.com",
        "ir.com",
      ]
      deny_effect = "block"
    }

    filesystem {
      allowed = [
        "/etc",
        "/usr/bin/",
        "/var/app",
      ]
      backdoor_files          = true
      check_new_files         = true
      denied                  = []
      deny_effect             = "prevent"
      skip_encrypted_binaries = false
      suspicious_elf_headers  = true
    }

    network {
      allowed_outbound_ips = []
      denied_outbound_ips     = []
      deny_effect             = "alert"
      detect_port_scan        = true
      skip_modified_processes = false
      skip_raw_sockets        = false

      allowed_listening_port {
        deny  = false
        end   = 443
        start = 443
      }

      allowed_outbound_port {
        deny  = false
        end   = 80
        start = 80
      }
      allowed_outbound_port {
        deny  = false
        end   = 443
        start = 443
      }
    }

    processes {
      allowed = [
        "aws-cni",
      ]
      check_crypto_miners    = true
      check_lateral_movement = true
      check_parent_child     = false
      check_suid_binaries    = false
      denied                 = []
      deny_effect            = "block"
      skip_modified          = false
      skip_reverse_shell     = false
    }
  }
}
```

## How Has This Been Tested?

See template above. I used 21.08.525 release of self-hosted Compute console.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
