### PR TITLE
feat: expose the `external` field in credentials resource

### DIFF
--- a/internal/convert/credential.go
+++ b/internal/convert/credential.go
@@ -26,6 +26,9 @@ func SchemaToCredential(d *schema.ResourceData) (auth.Credential, error) {
 	if val, ok := d.GetOk("description"); ok {
 		parsedCredential.Description = val.(string)
 	}
+	if val, ok := d.GetOk("external"); ok {
+		parsedCredential.External = val.(bool)
+	}
 	if val, ok := d.GetOk("role_arn"); ok {
 		parsedCredential.RoleArn = val.(string)
 	}

--- a/internal/provider/resource_credentials.go
+++ b/internal/provider/resource_credentials.go
@@ -61,6 +61,11 @@ func resourceCredentials() *schema.Resource {
 				Optional:    true,
 				Description: "Description of the credential.",
 			},
+			"external": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates if the credential is external (true) or not (false).",
+			},
 			"ibm_account_guid": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -148,6 +153,7 @@ func readCredentials(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("ca_cert", retrievedCredential.CaCert)
 	d.Set("description", retrievedCredential.Description)
+	d.Set("external", retrievedCredential.External)
 	d.Set("ibm_account_guid", retrievedCredential.AccountGUID)
 	d.Set("name", retrievedCredential.Id)
 	d.Set("role_arn", retrievedCredential.RoleArn)


### PR DESCRIPTION
## Description

Add the field `external` to be able to configure external credentials.

## Motivation and Context

Needed by a customer.

## How Has This Been Tested?

In production.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/1304237/166693466-7a584f5b-2569-4713-b4a9-a9bbd25cb9dc.png)
![image (1)](https://user-images.githubusercontent.com/1304237/166693491-bf1e7605-b9f9-45ee-824b-82d615b30842.png)
![image (2)](https://user-images.githubusercontent.com/1304237/166693506-826dcfe1-f638-4c2d-b60d-73763807a4af.png)


## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
