### PR TITLE
Add HTTP retry for 429

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"time"
 )
 
 type APIClientConfig struct {
@@ -65,7 +66,10 @@ func (c *Client) Request(method, endpoint string, query, data, response interfac
 	}
 	defer res.Body.Close()
 
+	// Retry in case backend responds with HTTP 429
+	// sleep for 3 seconds before retry
 	if res.StatusCode == 429 {
+		time.Sleep(3 * time.Second)
 		return c.Request(method, endpoint, query, data, &response)
 	}
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -65,6 +65,10 @@ func (c *Client) Request(method, endpoint string, query, data, response interfac
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode == 429 {
+		return c.Request(method, endpoint, query, data, &response)
+	}
+
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("Non-OK status: %d", res.StatusCode)
 	}


### PR DESCRIPTION
## Description

Fix for #54 

This is minimum impact implementation, and doesn't have retry backoff. Not having a backoff should be fine for HTTP 429, but if we want to add other error code in future (like HTTP 5xx), we also need to add backoff. Otherwise, we risk to get stuck in a case of infinite requests.

## How Has This Been Tested?

Tested with the following template:

```hcl
resource "prismacloudcompute_collection" "coderepo_collection" {
  count = 100
  name              = "test-coderepo-test-${count.index}"
  description       = "Collection for some coderepo"
  color             = "#FF0000"
  application_ids   = ["*"]
  code_repositories = ["some/test-app"]
  images            = ["*"]
  labels            = ["*"]
  namespaces        = ["*"]
  account_ids       = ["*"]
  clusters          = ["*"]
  containers        = ["*"]
  functions         = ["*"]
  hosts             = ["*"]
}
```


Created and destroyed the resources without any issues with HTTP throttling 

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
