### PR TITLE
remove stale trigger policy: docker

### DIFF
--- a/internal/api/alertprofile/alertprofile.go
+++ b/internal/api/alertprofile/alertprofile.go
@@ -146,13 +146,6 @@ type Defender struct {
 	Rules    []string `json:"rules,omitempty"`
 }
 
-// Access
-type Docker struct {
-	Enabled  bool     `json:"enabled"`
-	Allrules bool     `json:"allRules"`
-	Rules    []string `json:"rules,omitempty"`
-}
-
 // WAAS Firewall (host)
 type HostAppFirewall struct {
 	Enabled  bool     `json:"enabled"`
@@ -264,7 +257,6 @@ type Policy struct {
 	ContainerRuntime        ContainerRuntime        `json:"containerRuntime,omitempty"`
 	ContainerVulnerability  ContainerVulnerability  `json:"containerVulnerability,omitempty"`
 	Defender                Defender                `json:"defender,omitempty"`
-	Docker                  Docker                  `json:"docker,omitempty"`
 	HostAppFirewall         HostAppFirewall         `json:"hostAppFirewall,omitempty"`
 	HostCompliance          HostCompliance          `json:"hostCompliance,omitempty"`
 	HostComplianceScan      HostComplianceScan      `json:"hostComplianceScan,omitempty"`

--- a/internal/convert/alertprofile.go
+++ b/internal/convert/alertprofile.go
@@ -130,16 +130,6 @@ func AlertProfilePoliciesToSchema(d *alertprofile.Policy) interface{} {
 		}
 	}
 
-	if d.Docker.Enabled {
-		alertTriggerPolicies["docker"] = []interface{}{
-			map[string]interface{}{
-				"enabled":   d.Docker.Enabled,
-				"all_rules": d.Docker.Allrules,
-				"rules":     d.Docker.Rules,
-			},
-		}
-	}
-
 	if d.HostAppFirewall.Enabled {
 		alertTriggerPolicies["host_app_firewall"] = []interface{}{
 			map[string]interface{}{
@@ -399,15 +389,6 @@ func SchemaToAlertprofile(d *schema.ResourceData) (alertprofile.AlertProfile, er
 
 				for _, rule := range cv.(map[string]interface{})["rules"].([]interface{}) {
 					parsedAlertProfile.Policy.Defender.Rules = append(parsedAlertProfile.Policy.Defender.Rules, rule.(string))
-				}
-			}
-
-			for _, cv := range alertTrigger.(map[string]interface{})["docker"].([]interface{}) {
-				parsedAlertProfile.Policy.Docker.Enabled = cv.(map[string]interface{})["enabled"].(bool)
-				parsedAlertProfile.Policy.Docker.Allrules = cv.(map[string]interface{})["all_rules"].(bool)
-
-				for _, rule := range cv.(map[string]interface{})["rules"].([]interface{}) {
-					parsedAlertProfile.Policy.Docker.Rules = append(parsedAlertProfile.Policy.Docker.Rules, rule.(string))
 				}
 			}
 

--- a/internal/provider/resource_alertprofile.go
+++ b/internal/provider/resource_alertprofile.go
@@ -394,32 +394,6 @@ func resourceAlertprofile() *schema.Resource {
 								},
 							},
 						},
-						"docker": {
-							Type:        schema.TypeList,
-							MaxItems:    1,
-							Optional:    true,
-							Description: "Access",
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"enabled": {
-										Type:     schema.TypeBool,
-										Required: true,
-									},
-									"all_rules": {
-										Type:     schema.TypeBool,
-										Required: true,
-									},
-									"rules": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Computed: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-								},
-							},
-						},
 						"host_app_firewall": {
 							Type:        schema.TypeList,
 							MaxItems:    1,


### PR DESCRIPTION
## Description

Remove the `docker` alert type. It may have existed in the past? There's no documentation on https://pan.dev/search/?q=alert-profiles about this endpoint.

## Motivation and Context

Otherwise creating webhooks fail with: `... Non-OK status: 400 (invalid alert type docker)`

## How Has This Been Tested?

Manually on our tenant.

```terraform
resource "prismacloudcompute_alertprofile" "foo" {
  name                                    = "foo"
  enable_immediate_vulnerabilities_alerts = true
  webhook {
    url         = "xxxx"
    custom_json = <<-EOT
{
    "text": "type: #type"
}
EOT
  }

  policy {
    container_vulnerability {
      enabled   = true
      all_rules = false
      rules = [prismacloudcompute_image_vulnerability_policy.foo.rule[0].name]
    }
  }
}
```

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] ~All new and existing tests passed.~ existing ones are broken 😢
